### PR TITLE
Change olm head highlight from 1x1 tile to tile outline of full head

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.3'
+def runeLiteVersion = '1.8.30'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
@@ -30,7 +30,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -129,7 +128,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
     private boolean isInstanceTimerRunning = false;
 
     @Getter (AccessLevel.PACKAGE)
-    private LocalPoint olmTile = null;
+    private NPC olmHead = null;
 
     @Getter (AccessLevel.PACKAGE)
     private final List<String> tlList = new ArrayList<>();
@@ -195,7 +194,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
         coxHerb2 = null;
         coxHerbTimer2 = 16;
 
-        olmTile = null;
+        olmHead = null;
 
         ids.add(MAGE);
         ids.add(RANGE);
@@ -530,11 +529,11 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
                 {
                     if (id == 7551)
                     {
-                        olmTile = npc.getLocalLocation();
+                        olmHead = npc;
                     }
                     else if (id == 7554)
                     {
-                        olmTile = null;
+                        olmHead = null;
                     }
                 }
             }
@@ -556,7 +555,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
                 {
                     if (id == 7551)
                     {
-                        olmTile = null;
+                        olmHead = null;
                     }
                 }
             }
@@ -573,7 +572,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 
             if (id == 7554)
             {
-                olmTile = null;
+                olmHead = null;
             }
         }
     }

--- a/src/main/java/com/coxadditions/OlmSideOverlay.java
+++ b/src/main/java/com/coxadditions/OlmSideOverlay.java
@@ -6,8 +6,10 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import javax.inject.Inject;
+
+import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
-import net.runelite.api.Perspective;
+import net.runelite.api.NPC;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
@@ -34,19 +36,23 @@ public class OlmSideOverlay extends Overlay
 
     public Dimension render(Graphics2D graphics)
     {
-        if (config.olmSide() && plugin.getOlmTile() != null)
+        if (config.olmSide() && plugin.getOlmHead() != null)
         {
-            LocalPoint lp = plugin.getOlmTile();
+            NPC olmHead = plugin.getOlmHead();
+
+            LocalPoint lp = olmHead.getLocalLocation();
+            Polygon poly = olmHead.getCanvasTilePoly();
+
             if (lp != null)
             {
                 WorldPoint wp = WorldPoint.fromLocal(client, lp);
-                drawTile(graphics, wp, config.olmSideColor());
+                drawTile(graphics, wp, poly, config.olmSideColor());
             }
         }
         return null;
     }
 
-    protected void drawTile(Graphics2D graphics, WorldPoint point, Color color)
+    protected void drawTile(Graphics2D graphics, WorldPoint point, Polygon poly, Color color)
     {
         if (client.getLocalPlayer() != null)
         {
@@ -56,7 +62,6 @@ public class OlmSideOverlay extends Overlay
                 LocalPoint lp = LocalPoint.fromWorld(client, point);
                 if (lp != null)
                 {
-                    Polygon poly = Perspective.getCanvasTilePoly(client, lp);
                     if (poly != null)
                     {
                         graphics.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), 255));


### PR DESCRIPTION
Outline the full tile area (5x5) of olms head instead of a single tile. Do so by passing down the NPC object and getting the polygon from that directly, instead of getting a point and creating a 1x1 polygon.

I had to bump the runelite version for testing, not sure it needs to be bumped in the commit, but I don't think it hurts to update it.